### PR TITLE
Delete manual defenition NDEBUG from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,6 @@ else()
    project(allocator VERSION 0.0.1)
 endif()
 
-if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-	set(NDEBUG 1)
-endif()
-
 configure_file(ndebug.h.in ${PROJECT_SOURCE_DIR}/ndebug.h)
 
 file(GLOB HEADER_FILES ${PROJECT_SOURCE_DIR}/*.h)


### PR DESCRIPTION
Макрос `NDEBUG` автоматически добавляется через CMake в зависимости от типа сборки проекта.
https://github.com/Kitware/CMake/blob/c1f97af640231ff0cb90e4a1d9a567a2ee85daa5/Modules/Platform/Windows-MSVC.cmake#L284